### PR TITLE
Adding changes to write logs to a file for persistent logging

### DIFF
--- a/server.py
+++ b/server.py
@@ -5,6 +5,7 @@ from decrypter import Decrypter
 import binascii
 import settings
 import logging
+import logging.handlers
 
 app = Flask(__name__)
 
@@ -92,5 +93,6 @@ def decrypt():
 if __name__ == '__main__':
     # Startup
     logging.basicConfig(level=settings.LOGGING_LEVEL, format=settings.LOGGING_FORMAT)
-
+    handler = logging.handlers.RotatingFileHandler(settings.LOGGING_LOCATION, maxBytes=20000, backupCount=5)
+    app.logger.addHandler(handler)
     app.run(debug=True, host='0.0.0.0')

--- a/settings.py
+++ b/settings.py
@@ -19,5 +19,5 @@ PRIVATE_KEY = get_key(os.getenv('PRIVATE_KEY', "/keys/sdc-submission-encryption-
 PRIVATE_KEY_PASSWORD = os.getenv("PRIVATE_KEY_PASSWORD", "digitaleq")
 
 LOGGING_FORMAT = "%(asctime)s|%(levelname)s: %(message)s"
-LOGGING_LOCATION = "error.log"
+LOGGING_LOCATION = "logs/error.log"
 LOGGING_LEVEL = logging.DEBUG

--- a/settings.py
+++ b/settings.py
@@ -19,5 +19,5 @@ PRIVATE_KEY = get_key(os.getenv('PRIVATE_KEY', "/keys/sdc-submission-encryption-
 PRIVATE_KEY_PASSWORD = os.getenv("PRIVATE_KEY_PASSWORD", "digitaleq")
 
 LOGGING_FORMAT = "%(asctime)s|%(levelname)s: %(message)s"
-LOGGING_LOCATION = "logs/error.log"
+LOGGING_LOCATION = "logs/decrypt.log"
 LOGGING_LEVEL = logging.DEBUG


### PR DESCRIPTION
Changes to record logs to a file.

This change will create a log file that will persist after a build of sdx-decrypt for splunk to read. The file rotates once it reaches 2MB in size and will create 5 backup copies.

**To Test**
-  Create a folder 'logs' under your sdx-decrypt project.
-  Pull down latest docker compose code and rebuild the sdx-decrypt module in docker compose.
-  do `docker-compose up` and then using the console run through some surveys.
You should see a file appear in the logs folder called error.log with some logging in it.

**Who should test**
Anyone but Andy