### PR TITLE
Logging formatter for Filehandler

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,6 +1,6 @@
 from flask import Flask, request, jsonify, g
 from cryptography import exceptions
-
+from logging import Formatter
 from decrypter import Decrypter
 import binascii
 import settings
@@ -94,5 +94,6 @@ if __name__ == '__main__':
     # Startup
     logging.basicConfig(level=settings.LOGGING_LEVEL, format=settings.LOGGING_FORMAT)
     handler = logging.handlers.RotatingFileHandler(settings.LOGGING_LOCATION, maxBytes=20000, backupCount=5)
+    handler.setFormatter(Formatter(settings.LOGGING_FORMAT))
     app.logger.addHandler(handler)
     app.run(debug=True, host='0.0.0.0')


### PR DESCRIPTION
This PR adds to the file handler a formatter so that the log file contains a date and time for each log entry.

**To Test**
Pull down this PR and rebuild in docker compose.
Bring docker compose up and run some surveys through the console.
You should see logs with a date and time appearing in the decrypt.log file in the logs folder.

**Who Should Test**
Anyone but @howellsaj