### PR TITLE
configurable logging level

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -19,4 +19,4 @@ PRIVATE_KEY_PASSWORD = os.getenv("PRIVATE_KEY_PASSWORD", "digitaleq")
 
 LOGGING_FORMAT = "%(asctime)s|%(levelname)s: sdx-decrypt: %(message)s"
 LOGGING_LOCATION = "logs/decrypt.log"
-LOGGING_LEVEL = logging.DEBUG
+LOGGING_LEVEL = logging.getLevelName(os.getenv('LOGGING_LEVEL', 'DEBUG'))


### PR DESCRIPTION
**Changes**
Enables the logging level to be set by an environment variable

**How to test**
Should work the same by default
Set environment variable to a valid logging level

**Who can test**
Anyone but @elliott-jenkins