### PR TITLE
Update cryptography dependency to 1.5.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 cffi==1.5.2
-cryptography==1.2.3
+cryptography==1.5.3
 enum34==1.1.2
 Flask==0.10.1
 gunicorn==19.6.0


### PR DESCRIPTION
Nb. Service doesn't use dependency listed in requirements.txt - dependencies are held in the base docker image onsdigital/flask-cryto

Docker rebuild will update to new dependency as the base image is pulled in.

Closes #33