### PR TITLE
Update cffi and cryptography requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-cffi==1.5.2
-cryptography==1.5.3
+cffi==1.9.1
+cryptography==1.7.1
 enum34==1.1.2
 Flask==0.10.1
 gunicorn==19.6.0


### PR DESCRIPTION
Updates dependencies:
 - cryptography -> 1.7.1
 - cffi -> 1.9.1

