### PR TITLE
Log version number on server start and update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Unreleased
+  - Add version number to log
 
 ### 1.1.2 2017-02-16
   - Add change log

--- a/server.py
+++ b/server.py
@@ -16,8 +16,7 @@ logging.basicConfig(stream=sys.stdout, level=settings.LOGGING_LEVEL, format=sett
 logger = wrap_logger(
     logging.getLogger(__name__)
 )
-logger.debug("START")
-logger.info("Current version: {}".format(__version__))
+logger.info("START", version=__version__)
 
 
 def get_decrypter():

--- a/server.py
+++ b/server.py
@@ -8,6 +8,7 @@ import logging
 import sys
 import os
 
+__version__ = "1.1.2"
 
 app = Flask(__name__)
 
@@ -16,6 +17,7 @@ logger = wrap_logger(
     logging.getLogger(__name__)
 )
 logger.debug("START")
+logger.info("Current version: {}".format(__version__))
 
 
 def get_decrypter():


### PR DESCRIPTION
Logs the current version number on startup at INFO level. The version number is taken from the `__version__` variable in the `server.py` file, which will require manual updating when a new release is cut. It is currently configured to the most recent release (1.1.2).

If a setup.py file is introduced, the version number should be taken from there to ensure consistency.