### PR TITLE
Remove enum34 from requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python:
+    - "3.6"    
     - "3.5"
     - "3.4"
 install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Unreleased
+  - Remove enum34 from requirements.txt
+
 ### 1.3.0 2017-07-25
   - Change all instances of ADD to COPY in Dockerfile
   - Remove use of SDX_HOME variable in makefile

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 cffi==1.9.1
 cryptography==1.7.1
-enum34==1.1.2
 Flask==0.10.1
 gunicorn==19.6.0
 idna==2.0
@@ -17,3 +16,4 @@ sdx-common==0.7.0
 six==1.10.0
 structlog==16.1.0
 Werkzeug==0.11.9
+


### PR DESCRIPTION
## What? and Why?
This pull request removes the enum34 requirement from requirements.txt, which was causing travis python 3.6 builds to fail. Enum libraries shouldn't be specified in the requirements.txt file, as they are version dependent. It looks like the requirements.txt file was generated by doing `pip freeze > requirements.txt`, without thinking about possible issues. Closes #63.

## Checklist
  - [x] CHANGELOG.md updated? (if required)
