### PR TITLE
Travis python38

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 dist: xenial
 python:
+    - "3.8"
     - "3.7"
     - "3.6"
 sudo: required

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Unreleased
-
+  - Add python 3.8 to travis builds
+  
 ### 1.9.2 2019-09-26
   - Update werkzeug to 0.15.6 to fix security issue
   - Update all packages to latest version, where possible.


### PR DESCRIPTION
## What? and Why?
Add python 3.8 to travis builds so we can have confidence in our system when we end up upgrading the version of python we use

## Checklist
  - [x] CHANGELOG.md updated? (if required)
